### PR TITLE
Bugfixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ client.on("message", async message => {
   if (!routines.validate(message)) return;
   let messagesToDelete = new Discord.Collection();
   let lastInBatch = message;
-  const options = {limit: 100, before: message.id};
+  const options = {limit: 100, before: lastInBatch.id};
   while (lastInBatch) {
     const messagesToCheck = await message.channel.messages.fetch(options);
     tuple = await routines.clean(lastInBatch);
@@ -25,7 +25,7 @@ client.on("message", async message => {
   // Bulk deletion only works for messages younger than 14 days
   const deletedMessages = await message.channel.bulkDelete(messagesToDelete, true);
   // Difference returns the messages older than 14 days for one-by-one deletion
-  const olderMessagesToDelete = deletedMessages.difference(messagesToDelete);
+  const olderMessagesToDelete = messagesToDelete.difference(deletedMessages);
   olderMessagesToDelete.forEach(m => m.delete());
 });
 


### PR DESCRIPTION
Must have reverted these changes I made a while back by mistake while testing out a different way to organize the code.
1. The options object correctly uses the lastInBatch variable instead of the original message as the starting point for each search
2. The difference() call was used incorrectly. A.diff(B) means "the set of things in A but not B." A - B != B - A. The purpose of the difference() call is to get the messages older than 14 days. A contains all messages, B contains messages that are younger than 14 days, A.diff(B) = messages older than 14 days.