### PR TITLE
async/await style, fixed tests, start/finish messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-// A bot that deletes old, profane messages from text channels
+// A bot that deletes old, profane messages from Dicord guild text channels
 
 const routines = require("./routines.js");
 require("dotenv").config();
@@ -10,11 +10,12 @@ client.on("ready", () => {
   console.log(`Logged in as ${client.user.tag}!`);
 });
 
-client.on("message", async message => {
+client.on("message", message => {
   if (!routines.authorize(message.member.permissionsIn(message.channel))) return;
   if (!routines.validate(message)) return;
+  console.log("Started");
+  message.channel.send("Started");
   routines.clean(message);
 });
 
 client.login(process.env.DISCORD_TOKEN);
-

--- a/routines.js
+++ b/routines.js
@@ -1,58 +1,68 @@
 module.exports = {authorize, clean, validate};
 
 const Filter = require("bad-words");
-const filter = new Filter();
+let filter = new Filter();
 
 /**
- *  Checks if a user has enough guild privileges to execute bot commands
- *  @param {Permissions} permissions Permissions of the sender.
- *  @return {boolean} The user has sufficient privileges.
+ * Check if a user has enough guild privileges to execute bot commands
+ * @param {Permissions} permissions Permissions of the sender.
+ * @return {boolean} The user has sufficient privileges.
  */
 function authorize(permissions) {
   try {
+    if (!permissions || Object.keys(permissions).length === 0) return false;
     const admin = permissions.has("ADMINISTRATOR");
     const manage_messages = permissions.has("MANAGE_MESSAGES", false);
     const read_message_history = permissions.has("READ_MESSAGE_HISTORY", false);
     return admin || (manage_messages && read_message_history); 
   }
   catch (err) {
-    console.log(`routines.js: authenticate() - ${err}`);
-    return false;
+    console.log(err);
   }
 }
-
 /**
- *  Deletes messages containing profanity that are older than a given message
- *  @param {Message} message The message where cleaning begins.
+ * Keeps a count of the number of batches running. Only supports one cleanup at
+ * a time, globally. Probably need to make a class for some kind of
+ * "handleRequest" objects. Or find a better way of doing this altogether.
+*/
+var count = 0;
+/**
+ * Remove messages from a text channel that are older than a given message and
+ * contain profanity
+ * @param {Message} precedingMsg The message directly preceding the next batch.
  */
-async function clean(message) {
+async function clean(precedingMsg) {
+  if (!precedingMsg || Object.keys(precedingMsg).length === 0) return null;
   try {
-    message.channel.messages.fetch({limit: 100, before: message.id})
-      .then(messages => {
-        if (messages.last()) clean(messages.last());
-        return messages.filter(m => filter.isProfane(m.content));
-      })
-      .then(profaneMessages => profaneMessages.forEach(pm => pm.delete()));
+    count++;
+    const messages = await precedingMsg.channel.messages.fetch(
+      {limit: 100, before: precedingMsg.id}
+    );
+    clean(messages.last());
+    messages.filter(m => filter.isProfane(m.content)).forEach(m => m.delete());
+    if (--count == 0) {
+      console.log("Finished");
+      precedingMsg.channel.send("Finished");
+    }
   }
   catch (err) {
-    console.log(`routines.js: clean() - ${err}`);
+    console.log(err);
   }
 }
 
 /**
- *  Checks if a message is a command in a guild text channel
- *  @param {Message} message The message to validate.
- *  @return {boolean} The message is valid.
+ * Check if a message is a command in a guild text channel
+ * @param {Message} message The message to validate.
+ * @return {boolean} The message is valid.
  */
 function validate(message) {
   try {
+    if (!message || Object.keys(message).length === 0) return false;
     const command = message.content === "!clean";
     const textChannel = message.channel.type === "text";
     return command && textChannel;
   }
   catch (err) {
-    console.log(`routines.js: validate() - ${err}`);
-    return false;
+    console.log(err);
   }
 }
-

--- a/test/newleaf-test.js
+++ b/test/newleaf-test.js
@@ -2,18 +2,18 @@ const assert = require('assert');
 const routines = require("../routines.js");
 
 describe("routines.clean()", () => {
-  describe("# Bad object argument", () => {
+  describe("# Bad object", () => {
     it("should return null for null message", async () => {
-      const message= null;
-      assert.equal(await routines.clean(message), null);
+      const message = null;
+      assert.strictEqual(await routines.clean(message), null);
     });
     it("should return null for undefined message", async () => {
-      const message= undefined;
-      assert.equal(await routines.clean(message), null);
+      const message = undefined;
+      assert.strictEqual(await routines.clean(message), null);
     });
     it("should return null for empty object message", async () => {
-      const message= {};
-      assert.equal(await routines.clean(message), null);
+      const message = {};
+      assert.strictEqual(await routines.clean(message), null);
     });
   });
 });
@@ -36,37 +36,37 @@ describe("routines.authorize()", () => {
   };
   describe("# Authentication", () => {
     it("should return false non-privileged", () => {
-      assert.equal(routines.authorize(permissions), false);
+      assert.strictEqual(routines.authorize(permissions), false);
     });
     it("should return false for MANAGE_MESSAGES, but no READ_MESSAGE_HISTORY", () => {
       permissions.bitfield = 0b010;
-      assert.equal(routines.authorize(permissions), false);
+      assert.strictEqual(routines.authorize(permissions), false);
     });
     it("should return false for READ_MESSAGE_HISTORY, but no MANAGE_MESSAGES", () => {
       permissions.bitfield = 0b001;
-      assert.equal(routines.authorize(permissions), false);
+      assert.strictEqual(routines.authorize(permissions), false);
     });
     it("should return true for administrators", () => {
       permissions.bitfield = 0b100;
-      assert.equal(routines.authorize(permissions), true);
+      assert.strictEqual(routines.authorize(permissions), true);
     });
     it("should return true for MANAGE_MESSAGES and READ_MESSAGE_HISTORY", () => {
       permissions.bitfield = 0b011;
-      assert.equal(routines.authorize(permissions), true);
+      assert.strictEqual(routines.authorize(permissions), true);
     });
   });
-  describe("# Bad object argument", () => {
-    it("should return false for null argument", () => {
+  describe("# Bad object", () => {
+    it("should return false for null", () => {
       permissions = null;
-      assert.equal(routines.authorize(permissions), false);
+      assert.strictEqual(routines.authorize(permissions), false);
     });
-    it("should return false forundefined argument", () => {
+    it("should return false for undefined", () => {
       permissions = undefined;
-      assert.equal(routines.authorize(permissions), false);
+      assert.strictEqual(routines.authorize(permissions), false);
     });
-    it("should return false for empty argument", () => {
+    it("should return false for empty object", () => {
       permissions = {};
-      assert.equal(routines.authorize(permissions), false);
+      assert.strictEqual(routines.authorize(permissions), false);
     });
   });
 });
@@ -75,40 +75,40 @@ describe("routines.validate()", () => {
   describe("# Validation", () => {
     it("should return false for messages received on non-textchannels", () => {
       const message = {channel: {type: "not-text"}, content: "!clean"};
-      assert.equal(routines.validate(message), false);
+      assert.strictEqual(routines.validate(message), false);
     });
     it("should return false for invalid command messages", () => {
       const message = {channel: {type: "text"}, content: "not-!clean"};
-      assert.equal(routines.validate(message), false);
+      assert.strictEqual(routines.validate(message), false);
     });
     it("should return true for valid command messages received on a text channel", () => {
       const message = {channel: {type: "text"}, content: "!clean"};
-      assert.equal(routines.validate(message), true);
+      assert.strictEqual(routines.validate(message), true);
     });
   });
-  describe("# Bad object argument", () => {
-    it("should return false for null arguments", () => {
+  describe("# Bad object", () => {
+    it("should return false for null", () => {
       const message = null;
-      assert.equal(routines.validate(message), false);
+      assert.strictEqual(routines.validate(message), false);
     });
-    it("should return false for undefined arguments", () => {
+    it("should return false for undefined", () => {
       const message = undefined;
-      assert.equal(routines.validate(message), false);
+      assert.strictEqual(routines.validate(message), false);
     });
-    it("should return false for empty object argument", () => {
+    it("should return false for empty object", () => {
       const message = {};
-      assert.equal(routines.validate(message), false);
+      assert.strictEqual(routines.validate(message), false);
     });
   });
   // Discord API trims surrounding whitespace
   describe("$ Whitespace in command message", () => {
     it("should return false for leading whitespace",  () => {
       const message = {channel: {type: "text"}, content: " !clean"};
-      assert.equal(routines.validate(message), false);
+      assert.strictEqual(routines.validate(message), false);
     });
     it("should return false for trailing whitespace",  () => {
       const message = {channel: {type: "text"}, content: "!clean "};
-      assert.equal(routines.validate(message), false);
+      assert.strictEqual(routines.validate(message), false);
     });
   });
 });


### PR DESCRIPTION
1. Moved the clean function over to an async/await asynchronous style
2. Fixed function/tests relying on try-catch to return from the function. Replaced the now deprecated assert.equal. 
3. Start finish messages for the cleanup process. It relies on some weird counter variable that will not work for multiple cleanups running, globally. However, it is sufficient during development and testing. A "handleRequest" class may be called for to isolate each clean() call's counter. If I understand Javascript and asynchronous programming, race conditions do not exist for the shared memory. Pretty neat if true.